### PR TITLE
refactor autoscaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .hcloudauth
 dist
 coverage.out
+config-*.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 KUBECONFIG=$(HOME)/.kube/hcloud
 action=list-configurations
+config=config.yaml
 
 test:
 	./scripts/validate-license.sh
@@ -12,9 +13,9 @@ coverage:
 create-cluster:
 	make test
 	make delete-cluster
-	go run -race ./cmd -action=create -log.level=DEBUG
+	go run -race ./cmd -config=$(config) -action=create -log.level=DEBUG
 delete-cluster:
-	go run -race ./cmd -action=delete -log.level=DEBUG
+	go run -race ./cmd -config=$(config) -action=delete -log.level=DEBUG
 patch-cluster:
 	make run action=patch-cluster
 list-configurations:
@@ -22,21 +23,22 @@ list-configurations:
 upgrade-controlplane:
 	make run action=upgrade-controlplane
 run:
-	go run -race ./cmd -action=$(action) -log.level=DEBUG
+	go run -race ./cmd -config=$(config) -action=$(action) -log.level=DEBUG
 build:
 	go run github.com/goreleaser/goreleaser@latest build --rm-dist --skip-validate
 apply-yaml:
 	kubectl apply -f ./scripts
 apply-test:
+	kubectl apply -f examples/test-autoscaler.yaml
 	kubectl apply -f examples/test-deployment.yaml
 delete-test:
+	kubectl apply -f examples/test-autoscaler.yaml
 	kubectl delete -f examples/test-deployment.yaml
 test-kubernetes-yaml:
 	helm template ./scripts/chart | kubectl apply --dry-run=client --validate=true -f -
 	kubectl apply --dry-run=client --validate=true -f ./examples/test-deployment.yaml
 download-yamls:
 	curl -sSL -o ./scripts/chart/templates/kube-flannel.yml https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
-	curl -sSL -o ./scripts/chart/templates/ccm.yaml https://github.com/hetznercloud/hcloud-cloud-controller-manager/releases/latest/download/ccm.yaml
 	curl -sSL -o ./scripts/chart/templates/hcloud-csi.yml https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.6.0/deploy/kubernetes/hcloud-csi.yml
 	curl -sSL -o ./scripts/chart/templates/metrics-server.yml https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
 install:

--- a/examples/config-full.yaml
+++ b/examples/config-full.yaml
@@ -28,25 +28,8 @@ cliArgs:
   configpath: config.yaml
   action: list-configurations
 deploymentsConfig:
-  autoscalerconfig:
-    args:
-      - --v=4
-      - --cloud-provider=hetzner
-      - --stderrthreshold=info
-      - --expander=least-waste
-      - --scale-down-enabled=true
-      - --skip-nodes-with-local-storage=false
-      - --skip-nodes-with-system-pods=false
-      - --scale-down-utilization-threshold=0.8
-      - --nodes=0:20:CX11:{{ upper .Values.location }}:cx11
-      - --nodes=0:20:CX21:{{ upper .Values.location }}:cx21
-      - --nodes=0:20:CPX31:{{ upper .Values.location }}:cpx31
-      - --nodes=0:20:CPX41:{{ upper .Values.location }}:cpx41
-      - --nodes=0:20:CPX51:{{ upper .Values.location }}:cpx51
   ccmconfig:
     env:
-      - name: HCLOUD_NETWORK
-        value: "{{ .Values.clusterName }}"
       - name: HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP
         value: "true"
       - name: HCLOUD_LOAD_BALANCERS_LOCATION

--- a/examples/test-autoscaler.yaml
+++ b/examples/test-autoscaler.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-autoscaler
+  labels:
+    app: test-autoscaler
+spec:
+  replicas: 4
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: test-autoscaler
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+      labels:
+        app: test-autoscaler
+    spec:
+      terminationGracePeriodSeconds: 0
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - test-autoscaler
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - name: test-autoscaler
+        image: alpine:latest
+        imagePullPolicy: IfNotPresent
+        resources:
+          limits:
+            cpu: "7"
+            memory: 15Gi
+        command:
+        - sleep
+        - 1d

--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -16,6 +16,7 @@ import "time"
 
 const (
 	masterServersCount      = 3
+	workersCount            = 20
 	loadBalancerDefaultPort = 6443
 	waitTimeInRetry         = 3 * time.Second
 	retryTimeLimit          = 20

--- a/scripts/chart/templates/autoscaler.yaml
+++ b/scripts/chart/templates/autoscaler.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.autoscaler.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -158,7 +159,12 @@ spec:
             memory: 300Mi
         command:
         - ./cluster-autoscaler
-{{ tpl (toYaml .Values.deploymentsConfig.autoscalerconfig.args) . | indent 8 }}
+{{ tpl (toYaml .Values.autoscaler.args) . | indent 8 }}
+        {{- range $i, $worker := .Values.autoscaler.workers }}
+        {{- range $y, $type := $worker.type }}
+        - --nodes={{ $worker.min }}:{{ $worker.max }}:{{ upper $type }}:{{ upper (tpl (default $.Values.location $worker.datacenter) $) }}:{{ $type }}
+        {{- end }}
+        {{- end }}
         env:
         - name: HCLOUD_IMAGE
           value: "ubuntu-20.04"
@@ -195,3 +201,4 @@ spec:
   selector:
     matchLabels:
       app: cluster-autoscaler
+{{ end }}

--- a/scripts/chart/templates/ccm-networks.yaml
+++ b/scripts/chart/templates/ccm-networks.yaml
@@ -1,5 +1,4 @@
 # NOTE: this release was tested against kubernetes v1.18.x
-
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -26,7 +25,7 @@ metadata:
   name: hcloud-cloud-controller-manager
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 2
   selector:
     matchLabels:
@@ -38,6 +37,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: cloud-controller-manager
       dnsPolicy: Default
       tolerations:
@@ -51,18 +51,33 @@ spec:
         # cloud controller manages should be able to run on masters
         - key: "node-role.kubernetes.io/master"
           effect: NoSchedule
+          operator: Exists
         - key: "node-role.kubernetes.io/control-plane"
           effect: NoSchedule
+          operator: Exists
         - key: "node.kubernetes.io/not-ready"
           effect: "NoSchedule"
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - hcloud-cloud-controller-manager
+            topologyKey: kubernetes.io/hostname
+      hostNetwork: true
       containers:
         - image: hetznercloud/hcloud-cloud-controller-manager:v1.12.1
           name: hcloud-cloud-controller-manager
           command:
             - "/bin/hcloud-cloud-controller-manager"
             - "--cloud-provider=hcloud"
-            - "--leader-elect=false"
+            - "--leader-elect=true"
             - "--allow-untagged-cloud"
+            - "--allocate-node-cidrs=true"
+            - "--cluster-cidr=10.244.0.0/16"
           resources:
             requests:
               cpu: 100m

--- a/scripts/chart/templates/pdb.yaml
+++ b/scripts/chart/templates/pdb.yaml
@@ -8,3 +8,14 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-dns
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: hcloud-cloud-controller-manager
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: hcloud-cloud-controller-manager

--- a/scripts/chart/values.yaml
+++ b/scripts/chart/values.yaml
@@ -1,5 +1,28 @@
 clusterName: k8s
 location: nbg1
+workersCount: 20
+autoscaler:
+  enabled: true
+  args:
+  - --v=4
+  - --cloud-provider=hetzner
+  - --stderrthreshold=info
+  - --expander=least-waste
+  - --scale-down-enabled=true
+  - --skip-nodes-with-local-storage=false
+  - --skip-nodes-with-system-pods=false
+  - --scale-down-utilization-threshold=0.8
+  workers:
+  - datacenter: ""
+    min: 0
+    max: 20
+    type:
+    - cx11  
+    - cx21
+    - cpx31
+    - cpx41
+    - cx51
+    - cpx51
 deploymentsConfig:
   registry:
     enabled: false
@@ -13,21 +36,6 @@ deploymentsConfig:
       requests:
         cpu: 10m
         memory: 100Mi
-  autoscalerconfig:
-    args:
-    - --v=4
-    - --cloud-provider=hetzner
-    - --stderrthreshold=info
-    - --expander=least-waste
-    - --scale-down-enabled=true
-    - --skip-nodes-with-local-storage=false
-    - --skip-nodes-with-system-pods=false
-    - --scale-down-utilization-threshold=0.8
-    - --nodes=0:20:CX11:{{ upper .Values.location }}:cx11
-    - --nodes=0:20:CX21:{{ upper .Values.location }}:cx21
-    - --nodes=0:20:CPX31:{{ upper .Values.location }}:cpx31
-    - --nodes=0:20:CPX41:{{ upper .Values.location }}:cpx41
-    - --nodes=0:20:CPX51:{{ upper .Values.location }}:cpx51
   ccmconfig:
     env:
     - name: HCLOUD_NETWORK

--- a/scripts/init-master.sh
+++ b/scripts/init-master.sh
@@ -35,7 +35,7 @@ evictionHard:
   nodefs.inodesFree: "5%"
 EOF
 
-kubeadm init --upload-certs --config=/root/scripts/kubeadm-config.yaml
+kubeadm init --upload-certs --config=/root/scripts/kubeadm-config.yaml --v=5
 
 export KUBECONFIG=/etc/kubernetes/admin.conf
 


### PR DESCRIPTION
1. move autoscaling parameters to root level - now autoscaling can be customized by
```yaml
autoscaler:
  enabled: true
  args:
  - --v=4
  - --cloud-provider=hetzner
  - --stderrthreshold=info
  - --expander=least-waste
  - --scale-down-enabled=true
  - --skip-nodes-with-local-storage=false
  - --skip-nodes-with-system-pods=false
  - --scale-down-utilization-threshold=0.8
  workers:
  - datacenter: ""
    min: 0
    max: 20
    type:
    - cx11  
    - cx21
    - cpx31
    - cpx41
    - cx51
    - cpx51
 ```

2. move extra kubelet flags to `KubeletConfiguration` by path `/etc/kubernetes/kubelet/config.yaml`
3. host linux-image from update on node restart
4. use hetzner ipv4 nameservers
5. add `max-concurrent-uploads` to docker config

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>