### PR TITLE
add firewall on cluster creation

### DIFF
--- a/scripts/chart/templates/kube-flannel.yml
+++ b/scripts/chart/templates/kube-flannel.yml
@@ -212,6 +212,11 @@ spec:
           capabilities:
             add: ["NET_ADMIN", "NET_RAW"]
         env:
+        # use internal network
+        - name: FLANNELD_IFACE
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
on new cluster creation will be created firewalls to all servers in cluster. use ports that described in kubernetes docs https://kubernetes.io/docs/reference/ports-and-protocols/

_CHANGES_
- create firewalls with basic kubernetes rules on cluster creation
- patch flannel to use internal network



Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>