### PR TITLE
secure sshd

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,6 +77,7 @@ func main() { //nolint:cyclop
 		}
 
 		applicationAPI.ExecuteAdHoc(
+			*config.Get().CliArgs.AdhocUser,
 			*config.Get().CliArgs.AdhocCommand,
 			*config.Get().CliArgs.AdhocMasters,
 			*config.Get().CliArgs.AdhocCopyNewFile,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,7 @@ type cliArgs struct {
 	AdhocCommand     *string
 	AdhocCopyNewFile *bool
 	AdhocMasters     *bool
+	AdhocUser        *string
 }
 
 type masterServers struct {
@@ -102,6 +103,7 @@ var cliArguments = cliArgs{
 	AdhocCommand:     flag.String("adhoc.command", "", "command to adhoc action"),
 	AdhocCopyNewFile: flag.Bool("adhoc.copynewfile", false, "copy new files to adhoc action"),
 	AdhocMasters:     flag.Bool("adhoc.master", false, "run adhoc also on master servers"),
+	AdhocUser:        flag.String("adhoc.user", "", "ssh user for adhoc action"),
 }
 
 func defaultConfig() Type { //nolint:funlen


### PR DESCRIPTION
configure secure ssh settings to all servers in cluster

_CRITICAL CHANGES_
- disable root ssh login to all nodes
- use default `hcloud-user` for ssh login

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>