### PR TITLE
reduce Hetzner API calls

### DIFF
--- a/scripts/chart/templates/autoscaler.yaml
+++ b/scripts/chart/templates/autoscaler.yaml
@@ -153,7 +153,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - name: cluster-autoscaler
-        image: k8s.gcr.io/autoscaling/cluster-autoscaler:v1.23.1
+        image: paskalmaksim/cluster-autoscaler-amd64:fc3aefc3d
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/scripts/chart/templates/ccm.yaml
+++ b/scripts/chart/templates/ccm.yaml
@@ -35,6 +35,8 @@ spec:
       labels:
         app: hcloud-cloud-controller-manager
       annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8233'
         scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
     spec:
@@ -70,7 +72,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       hostNetwork: true
       containers:
-        - image: paskalmaksim/hcloud-cloud-controller-manager:6982aae2
+        - image: paskalmaksim/hcloud-cloud-controller-manager:15b5eabb
           imagePullPolicy: IfNotPresent
           name: hcloud-cloud-controller-manager
           command:

--- a/scripts/chart/templates/hcloud-csi.yml
+++ b/scripts/chart/templates/hcloud-csi.yml
@@ -111,6 +111,8 @@ spec:
       labels:
         app: hcloud-csi-controller
       annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9189'
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
     spec:
       serviceAccount: hcloud-csi
@@ -217,6 +219,8 @@ spec:
       labels:
         app: hcloud-csi
       annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9189'
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
     spec:
       tolerations:

--- a/scripts/chart/values.yaml
+++ b/scripts/chart/values.yaml
@@ -50,6 +50,8 @@ deployments:
         memory: 100Mi
   ccmconfig:
     env:
+    - name: HCLOUD_NETWORK_ROUTES_ENABLED
+      value: "false"
     - name: HCLOUD_NETWORK
       value: "{{ .Values.clusterName }}"
     - name: HCLOUD_LOAD_BALANCERS_USE_PRIVATE_IP


### PR DESCRIPTION
_CHANGES_
- add metrics for Hetzner API calls in [autoscaling](https://github.com/kubernetes/autoscaler) and [cloud-controller](https://github.com/hetznercloud/hcloud-cloud-controller-manager)
- add cached requests to corresponds Hetzner [ratelimits](https://docs.hetzner.cloud/#rate-limiting)
- disable hetzner networking routes in  [cloud-controller](https://github.com/hetznercloud/hcloud-cloud-controller-manager)

_Related To_
https://github.com/kubernetes/autoscaler/pull/5049
https://github.com/kubernetes/autoscaler/pull/5055
https://github.com/hetznercloud/hcloud-cloud-controller-manager/pull/303
https://github.com/hetznercloud/hcloud-cloud-controller-manager/pull/304


Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>