### PR TITLE
prepare scripts

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -99,6 +99,7 @@ func (api *ApplicationAPI) getCommonExecCommand() string {
 	return fmt.Sprintf(commonExecCommand,
 		config.Get().MasterServers.ServersInitParams.TarGz,
 		config.Get().MasterServers.ServersInitParams.Folder,
+		api.getDeploymentValues(),
 	)
 }
 
@@ -247,9 +248,7 @@ func (api *ApplicationAPI) postInstall(copyNewScripts bool) error {
 
 		log.Info("Executing command...")
 
-		postInstallCommand := fmt.Sprintf("VALUES=%s /root/scripts/post-install.sh", api.getDeploymentValues())
-
-		stdout, stderr, err := api.execCommand(serverIP, postInstallCommand)
+		stdout, stderr, err := api.execCommand(serverIP, "/root/scripts/post-install.sh")
 		if err != nil {
 			log.WithError(err).Fatal(stderr)
 		}

--- a/pkg/api/const.go
+++ b/pkg/api/const.go
@@ -30,7 +30,14 @@ curl -sSL -o scripts.tar.gz \
 tar -xvf scripts.tar.gz
 mv ./%s/scripts ./scripts
 
+# make scripts executables
 chmod +x /root/scripts/*.sh
+
+# initial config
+echo "%s" | base64 -d > /root/values.yaml
+
+# prepare scripts
+/root/scripts/prepare-scripts.sh
 `
 
 const kubeconfigFileMode = fs.FileMode(0o600)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,6 +89,13 @@ type masterLoadBalancer struct {
 	DestinationPort  int
 }
 
+type criConfigContainerd struct {
+	ExtraConfig string
+}
+type criConfig struct {
+	Containerd criConfigContainerd
+}
+
 //nolint:gochecknoglobals
 var config = Type{}
 
@@ -108,6 +115,7 @@ type Type struct {
 	CliArgs            cliArgs            `yaml:"cliArgs"`
 	Deployments        interface{}        `yaml:"deployments"` // values.yaml in chart
 	Autoscaler         autoscaler         `yaml:"autoscaler"`
+	Cri                criConfig          `yaml:"cri"`
 }
 
 //nolint:gochecknoglobals

--- a/scripts/common-install.sh
+++ b/scripts/common-install.sh
@@ -154,6 +154,9 @@ conf_dir = "/etc/cni/net.d"
 endpoint = ["http://10.100.0.11:5000"]
 [plugins."io.containerd.grpc.v1.cri".registry.mirrors."10.100.0.20:5000"]
 endpoint = ["http://10.100.0.20:5000"]
+
+# extra containerd config
+{{ .Values.cri.containerd.extraconfig }}
 EOF
 
 cat <<EOF | tee /etc/crictl.yaml
@@ -258,3 +261,5 @@ systemctl start kubelet containerd docker docker.socket
 
 # pull sandbox image
 ctr --namespace k8s.io image pull $PAUSE_CONTAINER
+
+# {{ .Values.ipRange }}

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -23,9 +23,6 @@ export KUBECONFIG=$KUBECONFIG_PATH
 # create annotation for recent node deletion
 kubectl annotate node --overwrite -lnode-role.kubernetes.io/master cluster-autoscaler.kubernetes.io/scale-down-disabled=true
 
-# create custom user values
-echo "$VALUES" | base64 -d > $SCRIPT_PATH/values.yaml
-
 # install helm for kubernetes deploymens
 curl -o helm.tar.gz https://get.helm.sh/helm-v3.4.2-linux-amd64.tar.gz
 tar -xvf helm.tar.gz

--- a/scripts/prepare-scripts.sh
+++ b/scripts/prepare-scripts.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Copyright paskal.maksim@gmail.com
+#
+# Licensed under the Apache License, Version 2.0 (the "License")
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -ex
+
+GO_TEMPLATE_VERSION=0.1.1
+
+# use go-binary to template script files
+curl -sSL -o /usr/local/bin/go-template https://github.com/maksim-paskal/go-template/releases/download/v${GO_TEMPLATE_VERSION}/go-template_${GO_TEMPLATE_VERSION}_linux_amd64
+chmod +x /usr/local/bin/go-template
+
+# create checksum file
+touch /tmp/checksum
+echo "59d980c91c52b2e2f0195aadd8b21d2ce1e9e514defb66e5f5d5495e804211aa  /usr/local/bin/go-template" >> /tmp/checksum
+
+# test downloaded script with sha256sum
+sha256sum -c /tmp/checksum
+
+# remove temp file
+rm /tmp/checksum
+
+# test binary
+go-template -version
+
+# template config files
+mv /root/scripts/common-install.sh /root/scripts/common-install.sh.tmpl
+
+# template common-install.sh script
+go-template \
+-file /root/scripts/common-install.sh.tmpl \
+--values /root/values.yaml \
+> /root/scripts/common-install.sh
+
+# make scripts executables
+chmod +x /root/scripts/*.sh


### PR DESCRIPTION
customize `common-install.sh` with extra containerd data from user data, templating shell scripts with [go-template](https://github.com/maksim-paskal/go-template)

add to config file:
```yaml
cri:
  containerd:
    extraconfig: |
      [plugins."io.containerd.grpc.v1.cri".registry.configs."registry:5005".auth]
      username = "user"
      password = "password"

      [plugins."io.containerd.grpc.v1.cri".registry.mirrors."git.alldigitalads.com:5005"]
      endpoint = ["http://10.100.0.11:5000"]

      [plugins."io.containerd.grpc.v1.cri".registry.configs."10.100.0.20:5000".tls]
      insecure_skip_verify = true
```

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>