### PR TITLE
kubernetes v1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ for other OS download binnary from [release pages](https://github.com/maksim-pas
 
 This will create 3 instance with 1 load balancer for kubernetes control plane and 1 kubernetes worker node,after successful installation cluster will have:
 
-- [Kubernetes v1.23](https://github.com/kubernetes/kubernetes)
+- [Kubernetes v1.24](https://github.com/kubernetes/kubernetes)
 - [Kubernetes Autoscaler](https://github.com/kubernetes/autoscaler)
 - [Flannel](https://github.com/flannel-io/flannel)
 - [Kubernetes Cloud Controller Manager for Hetzner Cloud](https://github.com/hetznercloud/hcloud-cloud-controller-manager)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,13 +89,6 @@ type masterLoadBalancer struct {
 	DestinationPort  int
 }
 
-type criConfigContainerd struct {
-	ExtraConfig string
-}
-type criConfig struct {
-	Containerd criConfigContainerd
-}
-
 //nolint:gochecknoglobals
 var config = Type{}
 
@@ -116,7 +109,8 @@ type Type struct {
 	CliArgs            cliArgs            `yaml:"cliArgs"`
 	Deployments        interface{}        `yaml:"deployments"` // values.yaml in chart
 	Autoscaler         autoscaler         `yaml:"autoscaler"`
-	Cri                criConfig          `yaml:"cri"`
+	PreStartScript     string             `yaml:"preStartScript"`
+	PostStartScript    string             `yaml:"postStartScript"`
 }
 
 //nolint:gochecknoglobals


### PR DESCRIPTION
_CHANGES_
- **upgrade kubernetes to v1.24**
- add `preStartScript` and `postStartScript` to additional configuration
- use containerd config from folders`/etc/containerd/certs.d:/etc/docker/certs.d`
- remove `cri.containerd.extraconfig` config

Signed-off-by: Maksim Paskal <paskal.maksim@gmail.com>