### PR TITLE
use full apt package name for kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ masterCount: 3
 serverComponents:
   kubernetes:
     # customize kubertenes version
-    version: 1.25.14
+    version: 1.25.14-1.1
   docker:
     # customize apt package version for docker install
     # apt-cache madison docker-ce
@@ -105,7 +105,7 @@ ipRange: "10.0.0.0/16"
 masterCount: 3
 serverComponents:
   kubernetes:
-    version: 1.25.14
+    version: 1.25.14-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:
@@ -139,7 +139,7 @@ ipRange: "10.0.0.0/16"
 masterCount: 3
 serverComponents:
   kubernetes:
-    version: 1.26.9
+    version: 1.26.9-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:
@@ -154,7 +154,7 @@ ipRange: "10.0.0.0/16"
 masterCount: 3
 serverComponents:
   kubernetes:
-    version: 1.27.6
+    version: 1.27.6-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:
@@ -169,7 +169,7 @@ ipRange: "10.0.0.0/16"
 masterCount: 3
 serverComponents:
   kubernetes:
-    version: 1.28.2
+    version: 1.28.2-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:
@@ -189,7 +189,7 @@ masterServers:
   servertype: cpx21
 serverComponents:
   kubernetes:
-    version: 1.28.2
+    version: 1.28.2-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:
@@ -210,7 +210,7 @@ serverComponents:
   ubuntu:
     architecture: arm
   kubernetes:
-    version: 1.28.2
+    version: 1.28.2-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:

--- a/e2e/configs/full.yaml
+++ b/e2e/configs/full.yaml
@@ -5,7 +5,7 @@ serverComponents:
     username: hcloud-user
     architecture: x86
   kubernetes:
-    version: 1.28.2
+    version: 1.28.2-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:

--- a/e2e/configs/v1.25.yaml
+++ b/e2e/configs/v1.25.yaml
@@ -3,7 +3,7 @@ ipRange: "10.0.0.0/16"
 masterCount: 3
 serverComponents:
   kubernetes:
-    version: 1.25.14
+    version: 1.25.14-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:

--- a/e2e/configs/v1.26.yaml
+++ b/e2e/configs/v1.26.yaml
@@ -3,7 +3,7 @@ ipRange: "10.0.0.0/16"
 masterCount: 3
 serverComponents:
   kubernetes:
-    version: 1.26.9
+    version: 1.26.9-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:

--- a/e2e/configs/v1.27.yaml
+++ b/e2e/configs/v1.27.yaml
@@ -3,7 +3,7 @@ ipRange: "10.0.0.0/16"
 masterCount: 3
 serverComponents:
   kubernetes:
-    version: 1.27.6
+    version: 1.27.6-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:

--- a/e2e/configs/v1.28-amd64-eu-central-fsn1.yaml
+++ b/e2e/configs/v1.28-amd64-eu-central-fsn1.yaml
@@ -3,7 +3,7 @@ ipRange: "10.0.0.0/16"
 masterCount: 3
 serverComponents:
   kubernetes:
-    version: 1.28.2
+    version: 1.28.2-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:

--- a/e2e/configs/v1.28-amd64-ubuntu-22.04.yaml
+++ b/e2e/configs/v1.28-amd64-ubuntu-22.04.yaml
@@ -5,7 +5,7 @@ serverComponents:
   ubuntu:
     version: ubuntu-22.04
   kubernetes:
-    version: 1.28.2
+    version: 1.28.2-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:

--- a/e2e/configs/v1.28-amd64-us-east-ash.yaml
+++ b/e2e/configs/v1.28-amd64-us-east-ash.yaml
@@ -8,7 +8,7 @@ masterServers:
   servertype: cpx21
 serverComponents:
   kubernetes:
-    version: 1.28.2
+    version: 1.28.2-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:

--- a/e2e/configs/v1.28-arm64-ubuntu-22.04.yaml
+++ b/e2e/configs/v1.28-arm64-ubuntu-22.04.yaml
@@ -6,7 +6,7 @@ serverComponents:
     version: ubuntu-22.04
     architecture: arm
   kubernetes:
-    version: 1.28.2
+    version: 1.28.2-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:

--- a/e2e/configs/v1.28-arm64.yaml
+++ b/e2e/configs/v1.28-arm64.yaml
@@ -5,7 +5,7 @@ serverComponents:
   ubuntu:
     architecture: arm
   kubernetes:
-    version: 1.28.2
+    version: 1.28.2-1.1
   docker:
     version: 5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -204,7 +204,7 @@ func defaultConfig() Type {
 				Architecture: hcloud.ArchitectureX86, // x86 or arm
 			},
 			Kubernetes: serverComponentKubernetes{
-				Version: "1.28.2",
+				Version: "1.28.2-1.1",
 			},
 			Docker: serverComponentDocker{
 				Version: "5:24.0.6-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)",

--- a/scripts/common-install.sh
+++ b/scripts/common-install.sh
@@ -206,7 +206,7 @@ EOF
 sysctl -p
 
 apt-mark unhold kubelet kubeadm kubectl
-apt-get install -y kubelet=${KUBERNETES_VERSION}-1.1 kubeadm=${KUBERNETES_VERSION}-1.1 kubectl=${KUBERNETES_VERSION}-1.1
+apt-get install -y kubelet=${KUBERNETES_VERSION} kubeadm=${KUBERNETES_VERSION} kubectl=${KUBERNETES_VERSION}
 apt-mark hold kubelet kubeadm kubectl
 
 # stop all services


### PR DESCRIPTION
new apt kubernetes packages has suffix `2.1`, use full package name in config

```
kubelet | 1.29.4-2.1 | https://pkgs.k8s.io/core:/stable:/v1.29/deb  Packages
kubelet | 1.29.3-1.1 | https://pkgs.k8s.io/core:/stable:/v1.29/deb  Packages
```