### PR TITLE
Use autoscaler workers from env

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -126,12 +127,18 @@ func getDefaultClusterAutoscaler() map[interface{}]interface{} {
 		defaultServers = append(defaultServers, strings.Split(instances, ",")...)
 	}
 
+	workersMaxSize := 20
+
+	if workersCountEnv, err := strconv.Atoi(os.Getenv("AUTOSCALER_WORKERS_MAX")); err == nil && workersCountEnv > 0 {
+		workersMaxSize = workersCountEnv
+	}
+
 	for _, location := range defaultLocations {
 		for _, server := range defaultServers {
 			result = append(result, &clusterAutoscalingGroup{
 				Name:         fmt.Sprintf("%s-%s", server, location),
 				MinSize:      0,
-				MaxSize:      workersCount,
+				MaxSize:      workersMaxSize,
 				InstanceType: server,
 				Region:       location,
 			})

--- a/pkg/config/const.go
+++ b/pkg/config/const.go
@@ -16,7 +16,6 @@ import "time"
 
 const (
 	masterServersCount          = 3
-	workersCount                = 20
 	loadBalancerDefaultPort     = 6443
 	waitTimeInRetry             = 3 * time.Second
 	retryTimeLimit              = 20


### PR DESCRIPTION
Default autoscaler workers is 20 - use `AUTOSCALER_WORKERS_MAX` env for change this value