### PR TITLE
feat: Increase number of nfs threads

### DIFF
--- a/scripts/chart/Chart.yaml
+++ b/scripts/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: hcloud-k8s-ctl
-version: 0.0.2
+version: 0.0.3
 dependencies:
 - name: nfs-subdir-external-provisioner
   version: "4.0.16"

--- a/scripts/chart/templates/nfs-server.yaml
+++ b/scripts/chart/templates/nfs-server.yaml
@@ -49,14 +49,10 @@ spec:
 {{ end }}
       containers:
       - name: nfs-server
-        # git clone git@github.com:sjiveson/nfs-server-alpine.git
-        # cd nfs-server-alpine
-        # remove --no-nfs-version 2 in nfsd.sh
-        # docker build . --platform=linux/amd64,linux/arm64 --pull --push -t paskalmaksim/nfs-server-alpine:$(date '+%Y%m%d')$(git rev-parse --short HEAD)
-        image: paskalmaksim/nfs-server-alpine:20231106ca320f7
+        image: {{ printf "%s:%s" .Values.deployments.nfs.server.image.repository .Values.deployments.nfs.server.image.tag }}
+        imagePullPolicy: {{ .Values.deployments.nfs.server.image.pullPolicy }}
         env:
-        - name: SHARED_DIRECTORY
-          value: "/exports"
+{{ toYaml .Values.deployments.nfs.server.env | indent 8 }}
         volumeMounts:
         - mountPath: /exports
           name: nfs-data

--- a/scripts/chart/values.yaml
+++ b/scripts/chart/values.yaml
@@ -9,6 +9,13 @@ deployments:
       nodeSelector: {}
       tolerations: []
       affinity: {}
+      image:
+        repository: paskalmaksim/nfs-server-alpine
+        tag: 20250115653a8da
+        pullPolicy: IfNotPresent
+      env:
+      - name: SHARED_DIRECTORY
+        value: "/exports"
     nfs-subdir-external-provisioner:
       enabled: false
   registry:


### PR DESCRIPTION
Increase number or nfs threads from 8 to 16 - to raise to higher values use env `RPCNFSDCOUNT`:

```yaml
deployments:
  nfs:
    server:
      env:
      - name: SHARED_DIRECTORY
        value: "/exports"
      - name: RPCNFSDCOUNT
        value: "16"
```

Closes: #133 