### PR TITLE
feat: Set default open files

### DIFF
--- a/scripts/common-install.sh
+++ b/scripts/common-install.sh
@@ -197,6 +197,12 @@ EOF
 
 modprobe br_netfilter overlay
 
+mkdir -p /etc/systemd/system/containerd.service.d/
+cat <<EOF | tee /etc/systemd/system/containerd.service.d/override.conf
+[Service]
+LimitNOFILE=65536
+EOF
+
 cat <<EOF | tee /etc/sysctl.conf
 net.bridge.bridge-nf-call-ip6tables=1
 net.bridge.bridge-nf-call-iptables=1


### PR DESCRIPTION
This pull request introduces a configuration change to the container runtime setup, specifically increasing the open file limit for the `containerd` service. This helps ensure better reliability and performance when running containers at scale.

Containerd service configuration:

* Created the directory `/etc/systemd/system/containerd.service.d/` and added an override configuration file to set `LimitNOFILE=65536` for the `containerd` service, increasing its maximum allowed open files.