### PR TITLE
fix: Typo

### DIFF
--- a/scripts/common-install.sh
+++ b/scripts/common-install.sh
@@ -187,7 +187,7 @@ EOF
 
 # set higher ulimit for containerd
 ctr oci spec | \
-jq '.process.rlimits = [{"type": "RLIMIT_NOFILE", "hard": 65536, "soft": 1048576}]' > /etc/containerd/base-runtime-spec.json
+jq '.process.rlimits = [{"type": "RLIMIT_NOFILE", "soft": 65536, "hard": 1048576}]' > /etc/containerd/base-runtime-spec.json
 
 cat <<EOF | tee /etc/crictl.yaml
 runtime-endpoint: unix:///var/run/containerd/containerd.sock


### PR DESCRIPTION
This pull request makes a minor adjustment to the containerd configuration in the `scripts/common-install.sh` script. The change corrects the order of the `soft` and `hard` values for the `RLIMIT_NOFILE` resource limit, ensuring that the `soft` limit is less than or equal to the `hard` limit.

* Corrected the order of `soft` and `hard` values in the `RLIMIT_NOFILE` setting for containerd's runtime spec to comply with expected configuration standards.