### PR TITLE
feat: Upgrade chart dependencies and update e2e config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 coverage.out
 config-*.yaml
 /scripts/chart/charts/
+/scripts/chart/tmpcharts/

--- a/e2e/configs/full.yaml
+++ b/e2e/configs/full.yaml
@@ -5,22 +5,22 @@ serverComponents:
     username: hcloud-user
     architecture: x86
   kubernetes:
-    version: 1.31.4-1.1
+    version: 1.33.7-1.1
   docker:
-    version: 5:27.4.1-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
+    version: 5:29.1.4-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
   containerd:
-    version: 1.7.24-1
-    pausecontainer: registry.k8s.io/pause:3.2
+    version: 2.2.1-1~ubuntu.$(lsb_release -rs)~$(lsb_release -cs)
+    pausecontainer: registry.k8s.io/pause:3.10
 ipRange: 10.0.0.0/16
 ipRangeSubnet: 10.0.0.0/16
 masterCount: 3
 networkZone: eu-central
-location: fsn1
-datacenter: fsn1-dc14
+location: hel1
+datacenter: hel1-dc2
 masterServers:
   namepattern: master-%d
   placementgroupname: master-placement-group
-  servertype: cx22
+  servertype: cx23
   labels:
     role: master
   waittimeinretry: 3s
@@ -48,6 +48,42 @@ cliArgs:
 deployments: {}
 preStartScript: ""
 postStartScript: ""
+kubelet:
+  authentication:
+    anonymous:
+      enabled: false
+    webhook:
+      cacheTTL: 2m0s
+      enabled: true
+    x509:
+      clientCAFile: /etc/kubernetes/pki/ca.crt
+  authorization:
+    mode: Webhook
+    webhook:
+      cacheAuthorizedTTL: 5m0s
+      cacheUnauthorizedTTL: 30s
+  cgroupDriver: systemd
+  clusterDNS:
+    - 10.96.0.10
+  clusterDomain: cluster.local
+  evictionHard:
+    memory.available: 100Mi
+    nodefs.available: 10%
+    nodefs.inodesFree: 5%
+  featureGates:
+    RotateKubeletServerCertificate: true
+  kubeReserved:
+    cpu: 10m
+    ephemeral-storage: 1Gi
+    memory: 100Mi
+  protectKernelDefaults: true
+  providerID: $PROVIDER_ID
+  resolvConf: /etc/kubernetes/kubelet/resolv.conf
+  rotateCertificates: true
+  runtimeRequestTimeout: 15m
+  serializeImagePulls: false
+  serverTLSBootstrap: true
+  staticPodPath: /etc/kubernetes/manifests
 cluster-autoscaler:
   autoscalingGroups:
     - name: cpx11-fsn1
@@ -60,40 +96,70 @@ cluster-autoscaler:
       maxSize: 20
       instanceType: cpx21
       region: fsn1
-    - name: cx22-fsn1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx22
-      region: fsn1
     - name: cpx31-fsn1
       minSize: 0
       maxSize: 20
       instanceType: cpx31
-      region: fsn1
-    - name: cx32-fsn1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx32
       region: fsn1
     - name: cpx41-fsn1
       minSize: 0
       maxSize: 20
       instanceType: cpx41
       region: fsn1
-    - name: cx42-fsn1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx42
-      region: fsn1
-    - name: cx52-fsn1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx52
-      region: fsn1
     - name: cpx51-fsn1
       minSize: 0
       maxSize: 20
       instanceType: cpx51
+      region: fsn1
+    - name: cpx12-fsn1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx12
+      region: fsn1
+    - name: cpx22-fsn1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx22
+      region: fsn1
+    - name: cpx32-fsn1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx32
+      region: fsn1
+    - name: cpx42-fsn1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx42
+      region: fsn1
+    - name: cpx52-fsn1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx52
+      region: fsn1
+    - name: cpx62-fsn1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx62
+      region: fsn1
+    - name: cx23-fsn1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx23
+      region: fsn1
+    - name: cx33-fsn1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx33
+      region: fsn1
+    - name: cx43-fsn1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx43
+      region: fsn1
+    - name: cx53-fsn1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx53
       region: fsn1
     - name: cpx11-nbg1
       minSize: 0
@@ -105,40 +171,70 @@ cluster-autoscaler:
       maxSize: 20
       instanceType: cpx21
       region: nbg1
-    - name: cx22-nbg1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx22
-      region: nbg1
     - name: cpx31-nbg1
       minSize: 0
       maxSize: 20
       instanceType: cpx31
-      region: nbg1
-    - name: cx32-nbg1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx32
       region: nbg1
     - name: cpx41-nbg1
       minSize: 0
       maxSize: 20
       instanceType: cpx41
       region: nbg1
-    - name: cx42-nbg1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx42
-      region: nbg1
-    - name: cx52-nbg1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx52
-      region: nbg1
     - name: cpx51-nbg1
       minSize: 0
       maxSize: 20
       instanceType: cpx51
+      region: nbg1
+    - name: cpx12-nbg1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx12
+      region: nbg1
+    - name: cpx22-nbg1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx22
+      region: nbg1
+    - name: cpx32-nbg1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx32
+      region: nbg1
+    - name: cpx42-nbg1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx42
+      region: nbg1
+    - name: cpx52-nbg1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx52
+      region: nbg1
+    - name: cpx62-nbg1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx62
+      region: nbg1
+    - name: cx23-nbg1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx23
+      region: nbg1
+    - name: cx33-nbg1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx33
+      region: nbg1
+    - name: cx43-nbg1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx43
+      region: nbg1
+    - name: cx53-nbg1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx53
       region: nbg1
     - name: cpx11-hel1
       minSize: 0
@@ -150,38 +246,68 @@ cluster-autoscaler:
       maxSize: 20
       instanceType: cpx21
       region: hel1
-    - name: cx22-hel1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx22
-      region: hel1
     - name: cpx31-hel1
       minSize: 0
       maxSize: 20
       instanceType: cpx31
-      region: hel1
-    - name: cx32-hel1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx32
       region: hel1
     - name: cpx41-hel1
       minSize: 0
       maxSize: 20
       instanceType: cpx41
       region: hel1
-    - name: cx42-hel1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx42
-      region: hel1
-    - name: cx52-hel1
-      minSize: 0
-      maxSize: 20
-      instanceType: cx52
-      region: hel1
     - name: cpx51-hel1
       minSize: 0
       maxSize: 20
       instanceType: cpx51
+      region: hel1
+    - name: cpx12-hel1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx12
+      region: hel1
+    - name: cpx22-hel1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx22
+      region: hel1
+    - name: cpx32-hel1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx32
+      region: hel1
+    - name: cpx42-hel1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx42
+      region: hel1
+    - name: cpx52-hel1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx52
+      region: hel1
+    - name: cpx62-hel1
+      minSize: 0
+      maxSize: 20
+      instanceType: cpx62
+      region: hel1
+    - name: cx23-hel1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx23
+      region: hel1
+    - name: cx33-hel1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx33
+      region: hel1
+    - name: cx43-hel1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx43
+      region: hel1
+    - name: cx53-hel1
+      minSize: 0
+      maxSize: 20
+      instanceType: cx53
       region: hel1

--- a/scripts/chart/Chart.lock
+++ b/scripts/chart/Chart.lock
@@ -1,24 +1,24 @@
 dependencies:
 - name: nfs-subdir-external-provisioner
   repository: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner
-  version: 4.0.16
+  version: 4.0.18
 - name: kubelet-csr-approver
   repository: https://postfinance.github.io/kubelet-csr-approver
-  version: 0.2.3
+  version: 1.2.14
 - name: hcloud-csi
   repository: https://charts.hetzner.cloud
-  version: 2.11.0
+  version: 2.20.2
 - name: hcloud-cloud-controller-manager
   repository: https://charts.hetzner.cloud
   version: 1.31.0
 - name: cluster-autoscaler
   repository: https://kubernetes.github.io/autoscaler
-  version: 9.43.2
+  version: 9.57.0
 - name: metrics-server
   repository: https://kubernetes-sigs.github.io/metrics-server
-  version: 3.12.2
+  version: 3.13.0
 - name: flannel
   repository: https://flannel-io.github.io/flannel
-  version: v0.26.2
-digest: sha256:033cbd53ad3ee48abd55fd0ac1ea3a354f0e3bf4aff76b5aeecff37c0d894e96
-generated: "2026-05-08T14:23:45.219149+02:00"
+  version: v0.28.4
+digest: sha256:14cbab3ff40c4a9381e667ca5d94ac31b72e12f1625d376e45e6ec6863ba32ec
+generated: "2026-05-12T08:15:13.203085+02:00"

--- a/scripts/chart/Chart.yaml
+++ b/scripts/chart/Chart.yaml
@@ -1,26 +1,26 @@
 apiVersion: v2
 name: hcloud-k8s-ctl
-version: 0.0.3
+version: 0.1.0
 dependencies:
 - name: nfs-subdir-external-provisioner
-  version: "4.0.16"
+  version: "4.0.18"
   repository: "https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner"
   condition: deployments.nfs.nfs-subdir-external-provisioner.enabled
 - name: kubelet-csr-approver
-  version: "0.2.3"
+  version: "1.2.14"
   repository: https://postfinance.github.io/kubelet-csr-approver
 - name: hcloud-csi
-  version: "2.11.0"
+  version: "2.20.2"
   repository: https://charts.hetzner.cloud
 - name: hcloud-cloud-controller-manager
   version: "1.31.0"
   repository: https://charts.hetzner.cloud
 - name: cluster-autoscaler
-  version: "9.43.2"
+  version: "9.57.0"
   repository: https://kubernetes.github.io/autoscaler
 - name: metrics-server
-  version: "3.12.2"
+  version: "3.13.0"
   repository: https://kubernetes-sigs.github.io/metrics-server
 - name: flannel
-  version: "v0.26.2"
+  version: "v0.28.4"
   repository: https://flannel-io.github.io/flannel

--- a/scripts/chart/values.yaml
+++ b/scripts/chart/values.yaml
@@ -78,9 +78,8 @@ kubelet-csr-approver:
 cluster-autoscaler:
   replicaCount: 2
   image:
-    # TODO: Remove after chart will have this version
-    # https://github.com/kubernetes/autoscaler/pull/7298
-    tag: v1.31.1
+    # Use the same version as you have in your cluster, e.g. v1.33.4 for Kubernetes 1.33
+    tag: v1.33.4
   priorityClassName: system-cluster-critical
   resources:
     requests:


### PR DESCRIPTION
- Bump chart version to 0.1.0
- Upgrade kubelet-csr-approver 0.2.3 -> 1.2.14
- Upgrade hcloud-csi 2.11.0 -> 2.20.2
- Upgrade cluster-autoscaler 9.43.2 -> 9.57.0
- Upgrade flannel v0.26.2 -> v0.28.4
- Upgrade metrics-server 3.12.2 -> 3.13.0
- Upgrade nfs-subdir-external-provisioner 4.0.16 -> 4.0.18
- Remove cluster-autoscaler image tag override (now in upstream chart)
- Update e2e config: k8s 1.33, docker 29, containerd 2.2, pause 3.10
- Switch e2e location to hel1, update server types cx -> cpx
- Add kubelet config and expand autoscaling groups in e2e
- Add tmpcharts to .gitignore